### PR TITLE
Bugfix for crash when scanning while attempting to join

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -40,6 +40,12 @@ config DEFAULT_AP_SSID
     help
 	SSID (network name) the the esp32 will broadcast.
 
+config WIFI_MANAGER_APPEND_MAC
+    bool "Append MAC address to access point SSID"
+    default n
+    help
+    The last two octets of the device's MAC address will be appended (with a preceding space) to the configured access point SSID. For example, "esp32" -> "esp32 ad7e". This helps make the SSID unique if you might have multiple devices on at once.
+
 config USE_RANDOM_AP_PASSWORD
 	bool "Use a randomly-generated Access Point password"
 	default y

--- a/Kconfig
+++ b/Kconfig
@@ -40,8 +40,12 @@ config DEFAULT_AP_SSID
     help
 	SSID (network name) the the esp32 will broadcast.
 
+config USE_RANDOM_AP_PASSWORD
+	bool "Use a randomly-generated Access Point password"
+	default y
+
 config DEFAULT_AP_PASSWORD
-    string "Access Point Password"
+    string "Access Point Password" if !USE_RANDOM_AP_PASSWORD
     default "esp32pwd"
     help
 	Password used for the Access Point. Leave empty and set AUTH MODE to WIFI_AUTH_OPEN for no password.

--- a/Kconfig
+++ b/Kconfig
@@ -20,13 +20,13 @@ config WIFI_MANAGER_MAX_RETRY_START_AP
 	int "Max Retry before starting the AP" if WIFI_MANAGER_AUTOSTART_AP
     default 3
     help
-	Defines the maximum number of failed retries allowed before the WiFi manager starts its own access point.  
-	
+	Defines the maximum number of failed retries allowed before the WiFi manager starts its own access point.
+
 config WIFI_MANAGER_SHUTDOWN_AP_TIMER
 	int "Time (in ms) to wait before shutting down the AP"
 	default 60000
 	help
-	Defines the time (in ms) to wait after a succesful connection before shutting down the access point.
+	Defines the time (in ms) to wait after a succesful connection before shutting down the access point. Use a negative number to never shut down the access point.
 
 config WEBAPP_LOCATION
     string "Defines the URL where the wifi manager is located"
@@ -91,5 +91,17 @@ config DEFAULT_AP_BEACON_INTERVAL
     default 100
     help
 	100ms is the recommended default.
+
+config HARDCODED_SSID
+  	string "Hardcoded SSID"
+  	default "HardcodedSSID"
+  	help
+  	For factory configuration, the device will attempt to connect an an AP with this SSID if there are no user configured APs.
+
+config HARDCODED_PASSWORD
+  	string "Hardcoded password"
+  	default "HardcodedPassword"
+  	help
+  	For factory configuration, the device will attempt to connect an an AP with this password if there are no user configured APs.
 
 endmenu

--- a/Kconfig
+++ b/Kconfig
@@ -12,8 +12,12 @@ config WIFI_MANAGER_RETRY_TIMER
 	help
 	Defines the time to wait before an attempt to re-connect to a saved wifi is made after connection is lost or another unsuccesful attempt is made.
 
+config WIFI_MANAGER_AUTOSTART_AP
+    bool "Automatically start the AP if the WiFi manager fails to connect to another AP"
+	default y
+
 config WIFI_MANAGER_MAX_RETRY_START_AP
-	int "Max Retry before starting the AP"
+	int "Max Retry before starting the AP" if WIFI_MANAGER_AUTOSTART_AP
     default 3
     help
 	Defines the maximum number of failed retries allowed before the WiFi manager starts its own access point.  

--- a/src/code.js
+++ b/src/code.js
@@ -105,6 +105,30 @@ docReady(async function () {
     false
   );
 
+  gel("togglepwd").addEventListener(
+    "click",
+    (e) => {
+      if (gel("pwd").type == "password") {
+        gel("pwd").type = "text";
+      } else {
+        gel("pwd").type = "password";
+      }
+    },
+    false
+  );
+
+  gel("manual_togglepwd").addEventListener(
+    "click",
+    (e) => {
+      if (gel("manual_pwd").type == "password") {
+        gel("manual_pwd").type = "text";
+      } else {
+        gel("manual_pwd").type = "password";
+      }
+    },
+    false
+  );
+
   gel("ok-details").addEventListener(
     "click",
     () => {

--- a/src/http_app.c
+++ b/src/http_app.c
@@ -172,7 +172,7 @@ static esp_err_t http_server_post_handler(httpd_req_t *req){
 			memcpy(config->sta.password, password, password_len);
 			ESP_LOGI(TAG, "ssid: %s, password: %s", ssid, password);
 			ESP_LOGD(TAG, "http_server_post_handler: wifi_manager_connect_async() call");
-			wifi_manager_connect_async();
+			wifi_manager_connect_async(true);
 
 			/* free memory */
 			free(ssid);
@@ -427,6 +427,7 @@ void http_app_start(bool lru_purge_enable){
 		 * We could register all URLs one by one, but this would not work while the fake DNS is active */
 		config.uri_match_fn = httpd_uri_match_wildcard;
 		config.lru_purge_enable = lru_purge_enable;
+		config.max_open_sockets = 2;
 
 		/* generate the URLs */
 		if(http_root_url == NULL){

--- a/src/http_app.c
+++ b/src/http_app.c
@@ -166,13 +166,9 @@ static esp_err_t http_server_post_handler(httpd_req_t *req){
 			httpd_req_get_hdr_value_str(req, "X-Custom-ssid", ssid, ssid_len+1);
 			httpd_req_get_hdr_value_str(req, "X-Custom-pwd", password, password_len+1);
 
-			wifi_config_t* config = wifi_manager_get_wifi_sta_config();
-			memset(config, 0x00, sizeof(wifi_config_t));
-			memcpy(config->sta.ssid, ssid, ssid_len);
-			memcpy(config->sta.password, password, password_len);
 			ESP_LOGI(TAG, "ssid: %s, password: %s", ssid, password);
 			ESP_LOGD(TAG, "http_server_post_handler: wifi_manager_connect_async() call");
-			wifi_manager_connect_async(true);
+			wifi_manager_connect_async(true, ssid, password);
 
 			/* free memory */
 			free(ssid);

--- a/src/index.html
+++ b/src/index.html
@@ -40,6 +40,7 @@
 						<input id="manual_pwd" type="password" placeholder="Password" value="">
 					</section>
 					<div class="buttons">
+							<input id="manual_togglepwd" class="big-button" type="button" value="Show password" /><br>
 							<input id="manual_join" type="button" value="Join" data-connect="manual" />
 							<input id="manual_cancel" type="button" value="Cancel"/>
 					</div>
@@ -53,6 +54,7 @@
 						<input id="pwd" type="password" placeholder="Password" value="">
 					</section>
 					<div class="buttons">
+							<input id="togglepwd" class="big-button" type="button" value="Show password" /><br>
 							<input id="join" type="button" value="Join" />
 							<input id="cancel" type="button" value="Cancel"/>
 					</div>

--- a/src/style.css
+++ b/src/style.css
@@ -28,6 +28,11 @@ input[type="button"] {
     text-align: center;
     display: block;
 }
+input[type="button"].big-button {
+    width: 90%;
+    max-width: 300px;
+    margin: auto;
+}
 p {
     padding: 10px;
 }

--- a/src/wifi_manager.c
+++ b/src/wifi_manager.c
@@ -1006,7 +1006,17 @@ void wifi_manager( void * pvParameters ){
 			.beacon_interval = DEFAULT_AP_BEACON_INTERVAL,
 		},
 	};
-	memcpy(ap_config.ap.ssid, wifi_settings.ap_ssid , sizeof(wifi_settings.ap_ssid));
+#ifdef CONFIG_WIFI_MANAGER_APPEND_MAC
+	/* Augment AP SSID with last bit of MAC address to make it more unique */
+	uint8_t mac_address[6];
+	if(((strlen((char *)wifi_settings.ap_ssid) + 6) < sizeof(wifi_settings.ap_ssid))
+		&& (esp_read_mac(mac_address, ESP_MAC_WIFI_STA) == ESP_OK)){
+		char buf[6];
+		sprintf(buf, " %02x%02x", (unsigned int)mac_address[4], (unsigned int)mac_address[5]);
+		strcat((char *)wifi_settings.ap_ssid, buf);
+	}
+#endif // CONFIG_WIFI_MANAGER_APPEND_MAC
+	memcpy(ap_config.ap.ssid, wifi_settings.ap_ssid, sizeof(wifi_settings.ap_ssid));
 
 	/* if the password lenght is under 8 char which is the minium for WPA2, the access point starts as open */
 	if(strlen( (char*)wifi_settings.ap_pwd) < WPA2_MINIMUM_PASSWORD_LENGTH){

--- a/src/wifi_manager.c
+++ b/src/wifi_manager.c
@@ -910,7 +910,9 @@ void wifi_manager( void * pvParameters ){
 	queue_message msg;
 	BaseType_t xStatus;
 	EventBits_t uxBits;
+#ifdef CONFIG_WIFI_MANAGER_AUTOSTART_AP
 	uint8_t	retries = 0;
+#endif // CONFIG_WIFI_MANAGER_AUTOSTART_AP
 
 
 	/* initialize the tcp stack */
@@ -1052,11 +1054,13 @@ void wifi_manager( void * pvParameters ){
 					ESP_LOGI(TAG, "Saved wifi found on startup. Will attempt to connect.");
 					wifi_manager_send_message(WM_ORDER_CONNECT_STA, (void*)CONNECTION_REQUEST_RESTORE_CONNECTION);
 				}
+#ifdef CONFIG_WIFI_MANAGER_AUTOSTART_AP
 				else{
 					/* no wifi saved: start soft AP! This is what should happen during a first run */
 					ESP_LOGI(TAG, "No saved wifi found on startup. Starting access point.");
 					wifi_manager_send_message(WM_ORDER_START_AP, NULL);
 				}
+#endif // CONFIG_WIFI_MANAGER_AUTOSTART_AP
 
 				/* callback */
 				if(cb_ptr_arr[msg.code]) (*cb_ptr_arr[msg.code])(NULL);
@@ -1189,8 +1193,10 @@ void wifi_manager( void * pvParameters ){
 					/* save NVS memory */
 					wifi_manager_save_sta_config();
 
+#ifdef CONFIG_WIFI_MANAGER_AUTOSTART_AP
 					/* start SoftAP */
 					wifi_manager_send_message(WM_ORDER_START_AP, NULL);
+#endif // CONFIG_WIFI_MANAGER_AUTOSTART_AP
 				}
 				else{
 					/* lost connection ? */
@@ -1205,6 +1211,7 @@ void wifi_manager( void * pvParameters ){
 					/* if it was a restore attempt connection, we clear the bit */
 					xEventGroupClearBits(wifi_manager_event_group, WIFI_MANAGER_REQUEST_RESTORE_STA_BIT);
 
+#ifdef CONFIG_WIFI_MANAGER_AUTOSTART_AP
 					/* if the AP is not started, we check if we have reached the threshold of failed attempt to start it */
 					if(! (uxBits & WIFI_MANAGER_AP_STARTED_BIT) ){
 
@@ -1221,6 +1228,7 @@ void wifi_manager( void * pvParameters ){
 							wifi_manager_send_message(WM_ORDER_START_AP, NULL);
 						}
 					}
+#endif // CONFIG_WIFI_MANAGER_AUTOSTART_AP
 				}
 
 				/* callback */
@@ -1292,8 +1300,10 @@ void wifi_manager( void * pvParameters ){
 					wifi_manager_save_sta_config();
 				}
 
+#ifdef CONFIG_WIFI_MANAGER_AUTOSTART_AP
 				/* reset number of retries */
 				retries = 0;
+#endif // CONFIG_WIFI_MANAGER_AUTOSTART_AP
 
 				/* refresh JSON with the new IP */
 				if(wifi_manager_lock_json_buffer( portMAX_DELAY )){

--- a/src/wifi_manager.c
+++ b/src/wifi_manager.c
@@ -147,6 +147,9 @@ struct wifi_settings_t wifi_settings = {
 	.sta_static_ip = 0,
 };
 
+/** Whether MAC has already been appended to the AP SSID. */
+static bool mac_appended_to_ssid;
+
 const char wifi_manager_nvs_namespace[] = "espwifimgr";
 
 static EventGroupHandle_t wifi_manager_event_group;
@@ -1211,11 +1214,13 @@ void wifi_manager( void * pvParameters ){
 #ifdef CONFIG_WIFI_MANAGER_APPEND_MAC
 	/* Augment AP SSID with last bit of MAC address to make it more unique */
 	uint8_t mac_address[6];
-	if(((strlen((char *)wifi_settings.ap_ssid) + 6) < sizeof(wifi_settings.ap_ssid))
+	if(!mac_appended_to_ssid
+		&& ((strlen((char *)wifi_settings.ap_ssid) + 6) < sizeof(wifi_settings.ap_ssid))
 		&& (esp_read_mac(mac_address, ESP_MAC_WIFI_STA) == ESP_OK)){
 		char buf[6];
 		sprintf(buf, " %02x%02x", (unsigned int)mac_address[4], (unsigned int)mac_address[5]);
 		strcat((char *)wifi_settings.ap_ssid, buf);
+		mac_appended_to_ssid = true;
 	}
 #endif // CONFIG_WIFI_MANAGER_APPEND_MAC
 	memcpy(ap_config.ap.ssid, wifi_settings.ap_ssid, sizeof(wifi_settings.ap_ssid));

--- a/src/wifi_manager.h
+++ b/src/wifi_manager.h
@@ -33,6 +33,7 @@ Contains the freeRTOS task and all necessary support
 #define WIFI_MANAGER_H_INCLUDED
 
 #include <stdbool.h>
+#include "esp_wifi.h"
 
 
 #ifdef __cplusplus

--- a/src/wifi_manager.h
+++ b/src/wifi_manager.h
@@ -353,7 +353,7 @@ wifi_config_t* wifi_manager_get_wifi_sta_config();
 /**
  * @brief requests a connection to an access point that will be process in the main task thread.
  */
-void wifi_manager_connect_async(bool save_config);
+void wifi_manager_connect_async(bool save_config, const char *ssid, const char *password);
 
 /**
  * @brief requests a wifi scan

--- a/src/wifi_manager.h
+++ b/src/wifi_manager.h
@@ -82,6 +82,12 @@ extern "C" {
  */
 #define WIFI_MANAGER_SHUTDOWN_AP_TIMER		CONFIG_WIFI_MANAGER_SHUTDOWN_AP_TIMER
 
+/**
+ * @brief Time (in ms) to wait before scan attempts
+ * Defines the time (in ms) to wait after failure before trying to start a scan again.
+ */
+#define WIFI_MANAGER_SCAN_RETRY				( 500 )
+
 
 /** @brief Defines the task priority of the wifi_manager.
  *


### PR DESCRIPTION
The main commit here (https://github.com/tonyp7/esp32-wifi-manager/commit/1af351eb578178e8e3be6d4d2484078198c1d81c) is to deal with an issue where if esp32-wifi-manager is attempting to join an AP using stored AP details and can't join, when it attempts to scan for new APs there will be a crash. For example:

User successfully connects ESP32 to their home router AP
User's home router AP spontaneously combusts
esp32-wifi-manager can't connect to user's home router AP, after CONFIG_WIFI_MANAGER_MAX_RETRY_START_AP tries it brings up its own AP
User purchases new router
User connects to esp32-wifi-manager to switch it over to the new router
esp32-wifi-manager will then crash. This is because join attempts to the old router are still happening in the background, but the user connecting to esp32-wifi-manager's AP will trigger scan requests. As per esp-idf documentation (https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/wifi.html#scan-when-wi-fi-is-connecting), esp_wifi_scan_start() will fail immediately if a join attempt is in progress. The use of the ESP_ERROR_CHECK macro then causes a crash.

The commit introduces a software timer which will retry the scan later if it fails.

The other commit (https://github.com/tonyp7/esp32-wifi-manager/commit/9ddab86e307167776bc86f7febc9e52ffe419eda) is just something to deal with compilation errors I was getting when trying to include wifi_manger.h in my own application.